### PR TITLE
Work-around to make it work with regex-impl branch

### DIFF
--- a/vertical-selection.kak
+++ b/vertical-selection.kak
@@ -5,7 +5,7 @@ define-command select-up %{
         # throw if we're at the top of the buffer
         exec -draft "hZk<a-z>a<a-space>"
         exec "<space><a-:><a-;>"
-        select-impl "<a-?>" "$"
+        select-impl "<a-?>" "\n"
         exec "<a-:>"
     }
 }


### PR DESCRIPTION
Reverse search for `$` is not working, but it seems using `\n` here works as well.